### PR TITLE
feat(AppInfo): add version name to list of installed apps tiles

### DIFF
--- a/lib/components/tiles.dart
+++ b/lib/components/tiles.dart
@@ -66,6 +66,9 @@ class InstalledAppTile extends StatelessWidget {
         subtitle: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            appInfo.versionName != null
+                ? Text("v${appInfo.versionName}")
+                : const SizedBox.shrink(),
             Text(appInfo.packageName),
             Row(
               children: [

--- a/lib/util/app_info.dart
+++ b/lib/util/app_info.dart
@@ -10,6 +10,7 @@ class AppInfo extends Comparable<AppInfo> {
   String? description;
   RemovalInfo? removalInfo;
   InstallInfo? installInfo;
+  String? versionName;
 
   AppInfo(
     this.name,
@@ -19,6 +20,7 @@ class AppInfo extends Comparable<AppInfo> {
     this.description,
     this.removalInfo,
     this.installInfo,
+    this.versionName
   });
 
   factory AppInfo.create(dynamic data) {
@@ -43,6 +45,7 @@ class AppInfo extends Comparable<AppInfo> {
       description: data["description"],
       removalInfo: removalInfo,
       installInfo: installInfo,
+      versionName: data["version_name"]
     );
   }
 


### PR DESCRIPTION
### What's new
- If the app has a non-null version name the tile for installed apps will show it
- AppInfo model has a versionName attribute

### Screenshot
![Screenshot_1709481344](https://github.com/samolego/Canta/assets/37549606/40ac8e8d-8720-4956-8acf-1e462ab995e6)
