### PR TITLE
Add custom text selection options with DeepL integration

### DIFF
--- a/app/src/main/java/org/samo_lego/canta/ui/dialog/AppInfoDialog.kt
+++ b/app/src/main/java/org/samo_lego/canta/ui/dialog/AppInfoDialog.kt
@@ -1,6 +1,10 @@
 package org.samo_lego.canta.ui.dialog
 
-import UrlText
+import androidx.compose.ui.viewinterop.AndroidView
+import android.text.Html
+import android.text.method.LinkMovementMethod
+import android.widget.TextView
+import org.samo_lego.canta.util.CustomTextSelectionCallback
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -18,7 +22,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
@@ -156,16 +159,36 @@ fun AppInfoDialog(
                     .heightIn(max = maxScrollableHeight)
                     .verticalScroll(rememberScrollState())
             ) {
-            if (bloatDescription != null) {
-                SelectionContainer {
-                    UrlText(text = bloatDescription)
-                }
-            } else {
-                Text(
-                        text = stringResource(R.string.no_description_available),
+                if (bloatDescription != null) {
+                    AndroidView(
+                        factory = { ctx ->
+                            TextView(ctx).apply {
+                                text =
+                                    Html.fromHtml(bloatDescription, Html.FROM_HTML_MODE_COMPACT)
+
+                                setTextIsSelectable(true)
+
+                                autoLinkMask = android.text.util.Linkify.WEB_URLS
+                                movementMethod = LinkMovementMethod.getInstance()
+
+                                setTextColor(androidx.core.content.ContextCompat.getColor(
+                                    context,
+                                    android.R.color.tab_indicator_text
+                                ))
+                                textSize = 14f
+
+                                customSelectionActionModeCallback =
+                                    CustomTextSelectionCallback(context, this)
+                            }
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                } else {
+                    Text(
+                        text = context.getString(R.string.no_description_available),
                         style = MaterialTheme.typography.bodySmall
-                )
-            }
+                    )
+                }
         }
             if (!appInfo.isUninstalled) {
                 Row(modifier = Modifier.align(Alignment.End)) {

--- a/app/src/main/java/org/samo_lego/canta/util/CustomTextSelectionCallback.kt
+++ b/app/src/main/java/org/samo_lego/canta/util/CustomTextSelectionCallback.kt
@@ -1,0 +1,103 @@
+package org.samo_lego.canta.util
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.view.ActionMode
+import android.view.Menu
+import android.view.MenuItem
+import android.widget.TextView
+
+
+class CustomTextSelectionCallback(
+    private val context: Context,
+    private val textView: TextView
+) : ActionMode.Callback {
+
+    companion object {
+        private const val MENU_ITEM_TRANSLATE_DEEPL = 100
+        private const val MENU_ITEM_SEARCH_GOOGLE = 101
+    }
+
+    override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
+        menu.add(Menu.NONE, MENU_ITEM_TRANSLATE_DEEPL, 5, "Translate with DeepL")
+            .setIcon(android.R.drawable.ic_menu_search) // Use a standard icon or your custom one
+
+        menu.add(Menu.NONE, MENU_ITEM_SEARCH_GOOGLE, 6, "Search")
+            .setIcon(android.R.drawable.ic_menu_search)
+
+        return true
+    }
+
+    override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
+        return false
+    }
+
+    override fun onActionItemClicked(mode: ActionMode, item: MenuItem): Boolean {
+        val selectedText = getSelectedText()
+
+        when (item.itemId) {
+            MENU_ITEM_TRANSLATE_DEEPL -> {
+                openDeepLTranslation(selectedText)
+                mode.finish()
+                return true
+            }
+            MENU_ITEM_SEARCH_GOOGLE -> {
+                searchOnGoogle(selectedText)
+                mode.finish()
+                return true
+            }
+        }
+
+        return false
+    }
+
+    override fun onDestroyActionMode(mode: ActionMode) {
+    }
+
+    private fun getSelectedText(): String {
+        val selectionStart = textView.selectionStart
+        val selectionEnd = textView.selectionEnd
+
+        if (selectionStart != selectionEnd) {
+            val min = selectionStart.coerceAtMost(selectionEnd)
+            val max = selectionStart.coerceAtLeast(selectionEnd)
+            if (min >= 0 && max <= textView.text.length) {
+                return textView.text.substring(min, max)
+            }
+        }
+        return ""
+    }
+
+    private fun openDeepLTranslation(text: String) {
+        if (text.isEmpty()) return
+
+        val encodedText = Uri.encode(text)
+
+        val deepLAppIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, text)
+            setPackage("com.deepl.mobiletranslator")
+        }
+
+        val packageManager = context.packageManager
+        val deepLAvailable = deepLAppIntent.resolveActivity(packageManager) != null
+
+        if (deepLAvailable) {
+            context.startActivity(deepLAppIntent)
+        } else {
+            val deepLUrl = "https://www.deepl.com/translator#auto/en/$encodedText"
+            val webIntent = Intent(Intent.ACTION_VIEW, Uri.parse(deepLUrl))
+            context.startActivity(webIntent)
+        }
+    }
+
+    private fun searchOnGoogle(text: String) {
+        if (text.isEmpty()) return
+
+        val encodedText = Uri.encode(text)
+        val searchUrl = "https://www.google.com/search?q=$encodedText"
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(searchUrl))
+        context.startActivity(intent)
+    }
+}


### PR DESCRIPTION
- Implement CustomTextSelectionCallback to extend native Android text selection menu
- Add "Translate with DeepL" option that opens the DeepL app if installed
- Add "Search" option for quick Google searches of selected text
- Replace Compose text components with AndroidView for native text selection handling
- Maintain HTML link support in app descriptions

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/80ccd7ff-f0e7-42a2-982c-ff60733fd8a4" alt="Screenshot_20250307-180535"></td>
    <td><img src="https://github.com/user-attachments/assets/f2824e11-0f4b-484c-8bdc-71446c5c1da5" alt="Screenshot_20250307-180515"></td>
  </tr>
</table>

Resolves #159