### PR TITLE
[feature] Add "Disabled" filter to app list

### DIFF
--- a/app/src/main/java/org/samo_lego/canta/util/Filter.kt
+++ b/app/src/main/java/org/samo_lego/canta/util/Filter.kt
@@ -45,6 +45,10 @@ class Filter(
                 Filter(name = "Unclassified", shouldShow = { app -> app.removalInfo == null })
             removalFilters.add(2, unclassified)
 
+            // Apps that are disabled
+            val disabled = Filter(name = "Disabled", shouldShow = { app -> app.isDisabled })
+            removalFilters.add(3, disabled)
+
             availableFilters = removalFilters
         }
     }


### PR DESCRIPTION
# Add "Disabled" filter to app list

I suggest adding a filter that displays only disabled apps, as that is what many users might do before they find out about this app. This makes it easier to batch remove all apps that were already disabled by the user.

## Changes:
- Added a new "Disabled" filter in the Filter class
- The filter shows only apps where the `isDisabled` property is true
- Positioned the filter after "Unclassified" in the filter selection list

This enhancement helps users quickly identify and manage applications they had previously disabled, streamlining the cleanup process when using Canta.

<img src="https://github.com/user-attachments/assets/a3dd76f7-198b-4fca-9bd4-a98d55f01b01" width="200">

Resolves #122 
