### PR TITLE
[feature] Uninstall updates before removing

### DIFF
--- a/app/src/main/java/org/samo_lego/canta/MainActivity.kt
+++ b/app/src/main/java/org/samo_lego/canta/MainActivity.kt
@@ -38,21 +38,23 @@ class MainActivity : ComponentActivity() {
         setContent {
             CantaTheme {
                 Surface(
-                        modifier = Modifier.fillMaxSize(),
-                        color = MaterialTheme.colorScheme.background
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
                 ) {
                     CantaApp(
-                            launchShizuku = {
-                                // Open shizuku app
-                                val launchIntent =
-                                        packageManager.getLaunchIntentForPackage(
-                                                SHIZUKU_PACKAGE_NAME
-                                        )
-                                startActivity(launchIntent)
-                            },
-                            uninstallApp = { uninstallApp(it) },
-                            reinstallApp = { reinstallApp(it) },
-                            closeApp =  { finishAndRemoveTask() },
+                        launchShizuku = {
+                            // Open shizuku app
+                            val launchIntent =
+                                packageManager.getLaunchIntentForPackage(
+                                    SHIZUKU_PACKAGE_NAME
+                                )
+                            startActivity(launchIntent)
+                        },
+                        uninstallApp = { packageName, resetToFactory ->
+                            uninstallApp(packageName, resetToFactory)
+                        },
+                        reinstallApp = { reinstallApp(it) },
+                        closeApp =  { finishAndRemoveTask() },
                     )
                 }
             }
@@ -60,53 +62,79 @@ class MainActivity : ComponentActivity() {
     }
 
     /**
-     * Uninstalls app using Shizuku. See <a
-     * href="https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/services/core/java/com/android/server/pm/PackageManagerShellCommand.java;drc=bcb2b436bde55ee40050400783a9c083e77ce2fe;l=2144">PackageManagerShellCommand.java</a>
+     * Uninstalls app using Shizuku.
      * @param packageName package name of the app to uninstall
+     * @param resetToFactory whether to reset system app to factory version before uninstall
      */
-    private fun uninstallApp(packageName: String): Boolean {
-        val broadcastIntent = Intent("org.samo_lego.canta.UNINSTALL_RESULT_ACTION")
-        val intent =
-                PendingIntent.getBroadcast(
-                        applicationContext,
-                        0,
-                        broadcastIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    private fun uninstallApp(packageName: String, resetToFactory: Boolean = false): Boolean {
+        val packageInfo = packageManager.getInfoForPackage(packageName)
+        val isSystem = (packageInfo.applicationInfo!!.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+        val hasUpdates = (packageInfo.applicationInfo!!.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0
+
+        val shouldReset = resetToFactory && isSystem && hasUpdates
+
+        LogUtils.i(APP_NAME, "Uninstalling '$packageName' [system: $isSystem, hasUpdates: $hasUpdates, resetFirst: $shouldReset]")
+
+        if (shouldReset) {
+            try {
+                LogUtils.i(APP_NAME, "Attempting to reset system app '$packageName' before uninstalling")
+
+                val packageInstaller = getPackageInstaller()
+                val flags = 0x00000002
+
+                val broadcastIntent = Intent("org.samo_lego.canta.UNINSTALL_RESULT_ACTION")
+                val intent = PendingIntent.getBroadcast(
+                    applicationContext,
+                    0,
+                    broadcastIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
                 )
 
+                HiddenApiBypass.invoke(
+                    PackageInstaller::class.java,
+                    packageInstaller,
+                    "uninstall",
+                    packageName,
+                    flags,
+                    intent.intentSender
+                )
+
+                LogUtils.i(APP_NAME, "Successfully reset system app '$packageName'")
+
+                try {
+                    val updatedPackageInfo = packageManager.getInfoForPackage(packageName)
+                    val stillHasUpdates = (updatedPackageInfo.applicationInfo!!.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0
+                    LogUtils.i(APP_NAME, "After reset: Package still has updates: $stillHasUpdates")
+                } catch (e: Exception) {
+                    LogUtils.e(APP_NAME, "Failed to check update status after reset: ${e.message}")
+                }
+
+            } catch (e: Exception) {
+                LogUtils.e(APP_NAME, "Failed to reset system app: ${e.message}")
+                LogUtils.w(APP_NAME, "Falling back to user uninstall")
+            }
+        }
+
+        val broadcastIntent = Intent("org.samo_lego.canta.UNINSTALL_RESULT_ACTION")
+        val intent = PendingIntent.getBroadcast(
+            applicationContext,
+            0,
+            broadcastIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
         val packageInstaller = getPackageInstaller()
-        val packageInfo = packageManager.getInfoForPackage(packageName)
-
-        val isSystem = (packageInfo.applicationInfo!!.flags and ApplicationInfo.FLAG_SYSTEM) != 0
-
-        LogUtils.i(APP_NAME, "Uninstalling '$packageName' [system: $isSystem]")
-
-        // 0x00000004 = PackageManager.DELETE_SYSTEM_APP
-        // 0x00000002 = PackageManager.DELETE_ALL_USERS
         val flags = if (isSystem) 0x00000004 else 0x00000002
 
         return try {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-                PackageInstaller::class
-                        .java
-                        .getDeclaredMethod(
-                                "uninstall",
-                                String::class.java,
-                                Int::class.javaPrimitiveType,
-                                PendingIntent::class.java
-                        )
-                        .invoke(packageInstaller, packageName, flags, intent)
-                // packageInstaller.uninstall(packageName, flags, intent.intentSender)
-            } else {
-                HiddenApiBypass.invoke(
-                        PackageInstaller::class.java,
-                        packageInstaller,
-                        "uninstall",
-                        packageName,
-                        flags,
-                        intent.intentSender
-                )
-            }
+            HiddenApiBypass.invoke(
+                PackageInstaller::class.java,
+                packageInstaller,
+                "uninstall",
+                packageName,
+                flags,
+                intent.intentSender
+            )
             true
         } catch (e: Exception) {
             LogUtils.e(APP_NAME, "Failed to uninstall '$packageName'")
@@ -125,12 +153,12 @@ class MainActivity : ComponentActivity() {
         val installReason = PackageManager.INSTALL_REASON_UNKNOWN
         val broadcastIntent = Intent("org.samo_lego.canta.INSTALL_RESULT_ACTION")
         val intent =
-                PendingIntent.getBroadcast(
-                        applicationContext,
-                        0,
-                        broadcastIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
+            PendingIntent.getBroadcast(
+                applicationContext,
+                0,
+                broadcastIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
 
         LogUtils.i(APP_NAME, "Reinstalling '$packageName'")
 
@@ -139,15 +167,15 @@ class MainActivity : ComponentActivity() {
 
         return try {
             HiddenApiBypass.invoke(
-                    IPackageInstaller::class.java,
-                    ShizukuPackageInstallerUtils.getPrivilegedPackageInstaller(),
-                    "installExistingPackage",
-                    packageName,
-                    installFlags,
-                    installReason,
-                    intent.intentSender,
-                    0,
-                    null
+                IPackageInstaller::class.java,
+                ShizukuPackageInstallerUtils.getPrivilegedPackageInstaller(),
+                "installExistingPackage",
+                packageName,
+                installFlags,
+                installReason,
+                intent.intentSender,
+                0,
+                null
             )
             true
         } catch (e: Exception) {
@@ -166,10 +194,10 @@ class MainActivity : ComponentActivity() {
         // The reason for use "com.android.shell" as installer package under adb is that
         // getMySessions will check installer package's owner
         return ShizukuPackageInstallerUtils.createPackageInstaller(
-                iPackageInstaller,
-                "com.android.shell",
-                userId,
-                this
+            iPackageInstaller,
+            "com.android.shell",
+            userId,
+            this
         )
     }
 }

--- a/app/src/main/java/org/samo_lego/canta/ui/dialog/UninstallDialog.kt
+++ b/app/src/main/java/org/samo_lego/canta/ui/dialog/UninstallDialog.kt
@@ -7,11 +7,17 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -22,9 +28,13 @@ import org.samo_lego.canta.R
 @Composable
 fun UninstallAppsDialog(
     appCount: Int,
+    isSystemApp: Boolean = false,
+    hasUpdates: Boolean = false,
     onDismiss: () -> Unit,
-    onAgree: () -> Unit,
+    onAgree: (resetToFactory: Boolean) -> Unit,
 ) {
+    var resetToFactory by remember { mutableStateOf(false) }
+
     BasicAlertDialog(
         modifier = Modifier
             .background(MaterialTheme.colorScheme.surfaceContainer, MaterialTheme.shapes.large),
@@ -35,11 +45,33 @@ fun UninstallAppsDialog(
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Text(stringResource(R.string.are_you_sure_to_uninstall_apps, appCount))
+
+            if (isSystemApp && hasUpdates) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = resetToFactory,
+                        onCheckedChange = { resetToFactory = it }
+                    )
+                    Text(
+                        text = stringResource(R.string.reset_to_factory_version),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
+                }
+            }
+
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End
             ) {
-                TextButton(onClick = onAgree) {
+                TextButton(
+                    onClick = { onAgree(resetToFactory) }
+                ) {
                     Text(stringResource(R.string.ok))
                 }
                 TextButton(
@@ -52,9 +84,26 @@ fun UninstallAppsDialog(
     }
 }
 
-
 @Preview
 @Composable
 fun UninstallAppsDialogPreview() {
-    UninstallAppsDialog(5, {}, {})
+    UninstallAppsDialog(
+        appCount = 5,
+        isSystemApp = true,
+        hasUpdates = true,
+        onDismiss = {},
+        onAgree = {}
+    )
+}
+
+@Preview
+@Composable
+fun UninstallAppsDialogRegularAppPreview() {
+    UninstallAppsDialog(
+        appCount = 1,
+        isSystemApp = false,
+        hasUpdates = false,
+        onDismiss = {},
+        onAgree = {}
+    )
 }

--- a/app/src/main/java/org/samo_lego/canta/util/Filter.kt
+++ b/app/src/main/java/org/samo_lego/canta/util/Filter.kt
@@ -45,6 +45,10 @@ class Filter(
                 Filter(name = "Unclassified", shouldShow = { app -> app.removalInfo == null })
             removalFilters.add(2, unclassified)
 
+            // Apps that are disabled
+            val disabled = Filter(name = "Disabled", shouldShow = { app -> app.isDisabled })
+            removalFilters.add(3, disabled)
+
             availableFilters = removalFilters
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,4 +68,7 @@
     <string
         name="select_all_enabled"
     >Select all has been enabled for filter type \"Recommended\".</string>
+    <string name="uninstall_options_title">Uninstall Options</string>
+    <string name="uninstall_app">Uninstall app</string>
+    <string name="reset_to_factory_version">Reset to factory version</string>
 </resources>


### PR DESCRIPTION
## Reset system apps feature

This PR adds the ability to reset system apps to their factory versions before uninstalling them. This helps users save storage space by removing updates before uninstallation.

### Changes:
- Modified `UninstallAppsDialog` to show a checkbox for resetting system apps when appropriate
- Updated `uninstallApp` function to accept a resetToFactory parameter
- Added helper function to detect system apps with updates
- Added proper error handling and verification of reset operation
- Added necessary string resources

### Testing:
Tested with multiple system apps including YouTube, YouTube Music, and Google apps. The reset option only appears for system apps that have updates installed.

The feature respects the user's choice at uninstall time, and logs provide verification of whether the reset was successful before proceeding with uninstall.

<img src="https://github.com/user-attachments/assets/f016cf6d-6b65-4e67-8768-f9fcd6624aa9" width="200">

Closes #173 