### PR TITLE
Fix RiskDialog issue & improve settings handling for stability #263

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
         android:supportsRtl="true"
         android:localeConfig="@xml/locales_config"
         android:theme="@style/Theme.Canta"
+        android:name=".CantaApplication"
         tools:targetApi="35">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/io/github/samolego/canta/CantaApplication.kt
+++ b/app/src/main/java/io/github/samolego/canta/CantaApplication.kt
@@ -1,0 +1,13 @@
+package io.github.samolego.canta
+
+import android.app.Application
+import io.github.samolego.canta.data.SettingsStore
+
+class CantaApplication: Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        // Initializing the SettingsStore
+        SettingsStore.initialize(applicationContext)
+    }
+}

--- a/app/src/main/java/io/github/samolego/canta/data/SettingsStore.kt
+++ b/app/src/main/java/io/github/samolego/canta/data/SettingsStore.kt
@@ -1,5 +1,6 @@
 package io.github.samolego.canta.data
 
+import android.annotation.SuppressLint
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
@@ -15,7 +16,8 @@ import kotlinx.coroutines.flow.map
 // Create a DataStore instance at the top level
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "canta_settings")
 
-class SettingsStore(private val context: Context) {
+// SettingsStore should be a singleton, ideally created once per application and provided via DI
+class SettingsStore private constructor(private val context: Context) {
 
     // Auto update bloat list preference
     val autoUpdateBloatListFlow: Flow<Boolean> = context.dataStore.data.map { preferences ->
@@ -39,9 +41,10 @@ class SettingsStore(private val context: Context) {
         }
     }
 
-    // Confirm before uninstall preference
+    // disable risk dialog preference
+    // false  == show, true == never show
     val disableRiskDialogFlow: Flow<Boolean> = context.dataStore.data.map { preferences ->
-        preferences[KEY_DISABLE_RISK_DIALOG] == true
+        preferences[KEY_DISABLE_RISK_DIALOG] ?: false
     }
 
     suspend fun setDisableRiskDialog(disable: Boolean) {
@@ -71,5 +74,26 @@ class SettingsStore(private val context: Context) {
         private val KEY_CONFIRM_BEFORE_UNINSTALL = booleanPreferencesKey("confirm_before_uninstall")
         private val KEY_DISABLE_RISK_DIALOG = booleanPreferencesKey("disable_risk_dialog")
         private val KEY_LATEST_BLOAT_COMMIT_HASH = stringPreferencesKey("latest_bloat_commit_hash")
+
+        @SuppressLint("StaticFieldLeak")
+        @Volatile
+        private var INSTANCE: SettingsStore? = null
+
+        // Initializes the SettingsStore singleton.
+        // Must be called from MyApplication.onCreate() before any attempt to get the instance.
+        fun initialize(appContext: Context) {
+            synchronized(this) {
+                if (INSTANCE == null) {
+                    INSTANCE = SettingsStore(appContext) // appContext.applicationContext
+                }
+            }
+        }
+
+        // to get SettingsStore instance this method should be called
+        fun getInstance(): SettingsStore {
+            return INSTANCE ?: throw IllegalStateException(
+                "SettingsStore has not been initialized. Call initialize() in MyApplication.onCreate()."
+            )
+        }
     }
 }

--- a/app/src/main/java/io/github/samolego/canta/ui/dialog/NoWarrantyDialog.kt
+++ b/app/src/main/java/io/github/samolego/canta/ui/dialog/NoWarrantyDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,7 +36,7 @@ fun NoWarrantyDialog(
     onProceed: (neverShowAgain: Boolean) -> Unit,
     onCancel: () -> Unit
 ) {
-    var neverShowAgain by remember { mutableStateOf(false) }
+    var neverShowAgain by rememberSaveable { mutableStateOf(false) }
 
     BasicAlertDialog(
         onDismissRequest = onCancel,

--- a/app/src/main/java/io/github/samolego/canta/ui/screen/SettingsPage.kt
+++ b/app/src/main/java/io/github/samolego/canta/ui/screen/SettingsPage.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -33,6 +34,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.samolego.canta.BuildConfig
 import io.github.samolego.canta.R
 import io.github.samolego.canta.ui.component.IconClickButton
@@ -49,15 +51,16 @@ fun SettingsScreen(
     onVersionTap: () -> Unit,
 ) {
     val context = LocalContext.current
-    val coroutineScope = rememberCoroutineScope()
-    val settingsStore = remember { SettingsStore(context) }
+    val autoUpdateBloatList by settingsViewModel.autoUpdateBloatList.collectAsStateWithLifecycle()
+    val confirmBeforeUninstall by settingsViewModel.confirmBeforeUninstall.collectAsStateWithLifecycle()
+    //val latestCommitHash by settingsViewModel.latestCommitHash.collectAsStateWithLifecycle()
 
-    var latestCommitHash = remember { mutableStateOf("") }
-
-    // Fetch the latest commit hash
-    LaunchedEffect(Unit) {
-        latestCommitHash.value = settingsStore.getLatestCommitHash()
-    }
+    // Haven't saw any use of LaunchEffect & latestCommitHash here in this Screen so they are commented.
+    // so please check
+//    // Fetch the latest commit hash
+//    LaunchedEffect(Unit) {
+//        latestCommitHash.value = settingsStore.getLatestCommitHash()
+//    }
 
     Scaffold(
         topBar = {
@@ -88,12 +91,9 @@ fun SettingsScreen(
                 description = stringResource(R.string.auto_update_bloat_list_description),
                 icon = Icons.Default.Update,
                 isSwitch = true,
-                checked = settingsViewModel.autoUpdateBloatList,
+                checked = autoUpdateBloatList,
                 onCheckedChange = {
-                    settingsViewModel.autoUpdateBloatList = it
-                    coroutineScope.launch {
-                        settingsViewModel.saveAutoUpdateBloatList(settingsStore)
-                    }
+                    settingsViewModel.saveAutoUpdateBloatList(it)
                 }
             )
 
@@ -103,12 +103,9 @@ fun SettingsScreen(
                 description = stringResource(R.string.confirm_uninstall_description),
                 icon = Icons.Default.Delete,
                 isSwitch = true,
-                checked = settingsViewModel.confirmBeforeUninstall,
+                checked = confirmBeforeUninstall,
                 onCheckedChange = {
-                    settingsViewModel.confirmBeforeUninstall = it
-                    coroutineScope.launch {
-                        settingsViewModel.saveConfirmBeforeUninstall(settingsStore)
-                    }
+                    settingsViewModel.saveConfirmBeforeUninstall(it)
                 }
             )
 

--- a/app/src/main/java/io/github/samolego/canta/ui/viewmodel/AppListViewModel.kt
+++ b/app/src/main/java/io/github/samolego/canta/ui/viewmodel/AppListViewModel.kt
@@ -85,7 +85,10 @@ class AppListViewModel : ViewModel() {
             val bloatFetcher = BloatUtils()
 
             // Get the auto-update preference
-            val settingsStore = SettingsStore(context)
+            // ideally it should be injected using DI but for now here SettingsStore.getInstance() is used as it provides the singleton instance of SettingsStore
+            // earlier it was creating a new instance of SettingsStore every time loadInstalled was called
+            // which is a bad practice as there should only be one instance of the preferences in app
+            val settingsStore = SettingsStore.getInstance()
             val autoUpdate = settingsStore.autoUpdateBloatListFlow.first()
 
             val uadLists: JSONObject = try {

--- a/app/src/main/java/io/github/samolego/canta/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/samolego/canta/ui/viewmodel/SettingsViewModel.kt
@@ -1,78 +1,137 @@
 package io.github.samolego.canta.ui.viewmodel
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
 import io.github.samolego.canta.data.SettingsStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
-class SettingsViewModel : ViewModel() {
+class SettingsViewModel(
+    // here we are injecting preferences dependencies directly into the viewModel
+    // now no need to manually inject the preferences every time in viewModel.
+    private val settingsStore: SettingsStore,
+    // savedStateHandle to (trying to) preserve the riskDialog visibility state across -
+    // configuration changes and system initiated process death
+    private val savedStateHandle: SavedStateHandle
+) : ViewModel() {
 
-    // Settings values
-    var autoUpdateBloatList by mutableStateOf(true)
-    var confirmBeforeUninstall by mutableStateOf(true)
-    var disableRiskDialog by mutableStateOf(false)
-    var latestCommitHash by mutableStateOf("")
+    private val _autoUpdateBloatList = MutableStateFlow<Boolean>(true)
+    val autoUpdateBloatList = _autoUpdateBloatList.asStateFlow()
 
-    fun loadSettings(settingsStore: SettingsStore) {
-        viewModelScope.launch {
-            // Collect auto update bloat list
-            settingsStore.autoUpdateBloatListFlow.collect {
-                autoUpdateBloatList = it
+    private val _confirmBeforeUninstall = MutableStateFlow<Boolean>(true)
+    val confirmBeforeUninstall = _confirmBeforeUninstall.asStateFlow()
+
+    private val _disableRiskDialog = MutableStateFlow<Boolean>(true)
+    val disableRiskDialog = _disableRiskDialog.asStateFlow()
+
+    private var _latestCommitHash = MutableStateFlow<String>("")
+    val latestCommitHashFlow = _latestCommitHash.asStateFlow()
+
+
+    init {
+        // here this will automatically starts observing and collecting values
+        // upon viewModel initialization from the preferences
+        // so no need to manually check the state
+        // also trying to maintain single source of truth
+
+        // you could also use something like this in other parts of the code for easy management.
+        observeSettings()
+        observeLatestCommitHash()
+        observeAutoUpdateBloatList()
+        observeConfirmBeforeUninstall()
+    }
+
+    private fun observeSettings() {
+        settingsStore.disableRiskDialogFlow
+            .onEach { neverShowRiskDialog ->
+                if (!neverShowRiskDialog) {
+                    val riskDialogSavedState =
+                        savedStateHandle.get<Boolean>(DISABLE_RISK_DIALOG_KEY) ?: false
+                    if (!riskDialogSavedState)
+                        _disableRiskDialog.value = false
+                }
             }
-        }
+            .launchIn(viewModelScope)
+    }
 
-        viewModelScope.launch {
-            // Collect confirm before uninstall
-            settingsStore.confirmBeforeUninstallFlow.collect {
-                confirmBeforeUninstall = it
+    private fun observeAutoUpdateBloatList() {
+        settingsStore.autoUpdateBloatListFlow
+            .onEach {
+                // preferred way to update the value is using .update { it } as it is thread safe
+                // but
+                // this is also correct/acceptable using .value = it
+                _autoUpdateBloatList.value = it
             }
-        }
+            .launchIn(viewModelScope)
+    }
 
-        viewModelScope.launch {
-            // Collect latest commit hash
-            settingsStore.latestCommitHashFlow.collect {
-                latestCommitHash = it
+    private fun observeConfirmBeforeUninstall() {
+        settingsStore.confirmBeforeUninstallFlow
+            .onEach {
+                _confirmBeforeUninstall.value = it
             }
-        }
+            .launchIn(viewModelScope)
+    }
 
-        viewModelScope.launch {
-            settingsStore.disableRiskDialogFlow.collect {
-                disableRiskDialog = it
+    private fun observeLatestCommitHash() {
+        settingsStore.latestCommitHashFlow
+            .onEach {
+                _latestCommitHash.value = it
             }
+            .launchIn(viewModelScope)
+    }
+
+    fun saveAutoUpdateBloatList(autoupdate: Boolean) {
+        viewModelScope.launch {
+            settingsStore.setAutoUpdateBloatList(autoupdate)
         }
     }
 
-    fun saveAutoUpdateBloatList(settingsStore: SettingsStore) {
-        viewModelScope.launch {
-            settingsStore.setAutoUpdateBloatList(autoUpdateBloatList)
-        }
-    }
-
-    fun saveConfirmBeforeUninstall(settingsStore: SettingsStore) {
+    fun saveConfirmBeforeUninstall(confirmBeforeUninstall: Boolean) {
         viewModelScope.launch {
             settingsStore.setConfirmBeforeUninstall(confirmBeforeUninstall)
         }
     }
 
-    fun saveLatestCommitHash(settingsStore: SettingsStore) {
+    fun saveLatestCommitHash(latestCommitHash: String) {
         viewModelScope.launch {
             settingsStore.setLatestCommitHash(latestCommitHash)
         }
     }
 
-    fun saveDisableRiskDialog(settingsStore: SettingsStore) {
+    fun saveDisableRiskDialog(permanentlyHide: Boolean) {
         viewModelScope.launch {
-            settingsStore.setDisableRiskDialog(disableRiskDialog)
+            if (permanentlyHide) {
+                settingsStore.setDisableRiskDialog(true)
+            }
+            _disableRiskDialog.value = true
+            savedStateHandle[DISABLE_RISK_DIALOG_KEY] = true
         }
     }
 
-    fun saveSettings(store: SettingsStore) {
-        saveAutoUpdateBloatList(store)
-        saveConfirmBeforeUninstall(store)
-        saveLatestCommitHash(store)
-        saveDisableRiskDialog(store)
+    private companion object {
+        // this is a key to store the value in the savedStateHandle
+        const val DISABLE_RISK_DIALOG_KEY = "disable_risk_dialog"
+    }
+}
+
+// Factory to create SettingsViewModel with required dependencies using manual dependency injection
+// as this app opt no to choose any other DI framework so i tried manual DI
+class SettingsViewModelFactory : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+        if (modelClass.isAssignableFrom(SettingsViewModel::class.java)) {
+            val savedStateHandle = extras.createSavedStateHandle()
+            val settingsStore = SettingsStore.getInstance()
+            return SettingsViewModel(settingsStore, savedStateHandle) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
     }
 }


### PR DESCRIPTION
**Bug Fix:**
- Prevents RiskDialog reappearance by preserving temporary acceptance through config changes and system-initiated process death.
- Fixed triggers causing reappearance:
  1. Immediately after initial acceptance.
  2. On configuration changes (e.g., theme switch).
  3. When the system initiated process.

**Dialog State Improvements:**
- Simplified state management for NoWarrantyDialog(RiskDialog) and ExplainBadgeDialog(BadgeInfo) and survive configuration changes.

**Best Practices & Stability Improvements:**
- Removed creation of multiple `SettingsStore` instances across composables, which could lead to inconsistent state and potential memory leaks if tied to Activity context.
- Implemented a Singleton `SettingsStore`
- Introduced manual dependency injection via `ViewModelProvider.Factory` for `SettingsViewModel` to ensure consistent SettingsStore instance usage across the app, compensating for the absence of an existing DI framework.
- Reduces memory‑leak risk, improves stability, and adopts recommended practices for SettingsStore and SettingsViewModel.