### PR TITLE
fix: broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ https://crowdin.com/project/canta
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=samolego/Canta&type=Date)](https://star-history.com/#samolego/Canta&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=samolego/Canta&type=Date)](https://star-history.dera.page/#samolego/Canta&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken and needs a fix. This changes it to star-history.dera.page, which provides the same chart through a different data source that requires no API token, keeping the chart up to date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart image and link to use the new hosting service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->