### PR TITLE
Add sorting options and app size to app list

### DIFF
--- a/app/src/main/java/io/github/samolego/canta/ui/component/AppList.kt
+++ b/app/src/main/java/io/github/samolego/canta/ui/component/AppList.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
@@ -66,6 +67,15 @@ fun AppList(
                 }
             }
         }
+    }
+
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(
+        appListModel.sortedBy,
+        appListModel.selectedFilter
+    ) {
+        listState.scrollToItem(0)
     }
 
     val selectedAppList by remember {
@@ -178,8 +188,9 @@ fun AppList(
 
             if (appList.isNotEmpty()) {
                 LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = WindowInsets.navigationBars.asPaddingValues()
+                    modifier = Modifier.fillMaxSize(),
+                    state = listState,
+                    contentPadding = WindowInsets.navigationBars.asPaddingValues()
                 ) {
                     items(appList, key = { it.packageName }) { appInfo ->
                         AppTile(

--- a/app/src/main/java/io/github/samolego/canta/ui/component/AppTile.kt
+++ b/app/src/main/java/io/github/samolego/canta/ui/component/AppTile.kt
@@ -1,6 +1,7 @@
 package io.github.samolego.canta.ui.component
 
 import android.graphics.drawable.Drawable
+import android.text.format.Formatter
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -84,6 +85,16 @@ fun AppTile(
                                 modifier = Modifier.fillMaxWidth(),
                                 horizontalArrangement = Arrangement.SpaceBetween,
                         ) { Text(appInfo.packageName, modifier = Modifier.weight(9f)) }
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
+                            Text(
+                                Formatter.formatFileSize(LocalContext.current, appInfo.size),
+                                modifier = Modifier.weight(9f)
+                            )
+                        }
 
                         FlowRow {
                             if (appInfo.removalInfo != null) {
@@ -192,6 +203,7 @@ fun CantaAppTileDemo() {
                                             description = "Canta is not a system app",
                                             removal = RemovalRecommendation.RECOMMENDED,
                                     ),
+                        size = 10000
                     ),
             isSelected = false,
             enabled = false,
@@ -220,6 +232,7 @@ fun LongTileDemo() {
                                             description = "Canta is a system app",
                                             removal = RemovalRecommendation.RECOMMENDED,
                                     ),
+                        size = 0
                     ),
             isSelected = false,
             onCheckChanged = {},

--- a/app/src/main/java/io/github/samolego/canta/ui/component/AppTopBar.kt
+++ b/app/src/main/java/io/github/samolego/canta/ui/component/AppTopBar.kt
@@ -10,10 +10,12 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.FilterAlt
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.SortByAlpha
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -39,6 +41,7 @@ import io.github.samolego.canta.APP_NAME
 import io.github.samolego.canta.R
 import io.github.samolego.canta.ui.menu.FiltersMenu
 import io.github.samolego.canta.ui.menu.MoreOptionsMenu
+import io.github.samolego.canta.ui.menu.SortByOptions
 import io.github.samolego.canta.ui.viewmodel.AppListViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -50,6 +53,7 @@ fun CantaTopBar(
 ) {
     var showMoreOptionsMenu by remember { mutableStateOf(false) }
     var showFiltersMenu by remember { mutableStateOf(false) }
+    var showSortByOptionsMenu by remember { mutableStateOf(false) }
     var searchActive by remember { mutableStateOf(false) }
     val searchFocusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -131,6 +135,12 @@ fun CantaTopBar(
                 )
 
                 IconClickButton(
+                    onClick = { showSortByOptionsMenu = !showSortByOptionsMenu },
+                    icon = Icons.AutoMirrored.Default.Sort,
+                    contentDescription = "Sort by"
+                )
+
+                IconClickButton(
                         onClick = { showFiltersMenu = !showFiltersMenu },
                         icon = Icons.Default.FilterAlt,
                         contentDescription = "Filter"
@@ -140,6 +150,12 @@ fun CantaTopBar(
                         onClick = { showMoreOptionsMenu = !showMoreOptionsMenu },
                         icon = Icons.Default.MoreVert,
                         contentDescription = "More options",
+                )
+
+                SortByOptions(
+                    showMenu = showSortByOptionsMenu,
+                    onDismiss = { showSortByOptionsMenu = false },
+                    appListViewModel = appListViewModel,
                 )
 
                 FiltersMenu(

--- a/app/src/main/java/io/github/samolego/canta/ui/menu/SortByOptions.kt
+++ b/app/src/main/java/io/github/samolego/canta/ui/menu/SortByOptions.kt
@@ -1,0 +1,73 @@
+package io.github.samolego.canta.ui.menu
+
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.samolego.canta.ui.viewmodel.AppListViewModel
+
+data class SortOption(
+    val field: SortField,
+    val direction: SortDirection,
+    val label: String
+)
+
+enum class SortField {
+    NAME,
+    PACKAGE_NAME,
+    VERSION,
+    SIZE
+}
+
+enum class SortDirection {
+    ASCENDING,
+    DESCENDING
+}
+
+val sortOptions = listOf(
+    SortOption(SortField.NAME, SortDirection.ASCENDING, "Name: A → Z"),
+    SortOption(SortField.NAME, SortDirection.DESCENDING, "Name: Z → A"),
+    SortOption(SortField.PACKAGE_NAME, SortDirection.ASCENDING, "Package: A → Z"),
+    SortOption(SortField.PACKAGE_NAME, SortDirection.DESCENDING, "Package: Z → A"),
+    SortOption(SortField.SIZE, SortDirection.ASCENDING, "Size: Low → High"),
+    SortOption(SortField.SIZE, SortDirection.DESCENDING, "Size: High → Low"),
+    SortOption(SortField.VERSION, SortDirection.ASCENDING, "Version: Low → High"),
+    SortOption(SortField.VERSION, SortDirection.DESCENDING, "Version: High → Low")
+)
+
+@Composable
+fun SortByOptions(
+    showMenu: Boolean,
+    onDismiss: () -> Unit,
+    appListViewModel: AppListViewModel
+) {
+    DropdownMenu(
+        expanded = showMenu,
+        onDismissRequest = onDismiss,
+        modifier = Modifier.width(180.dp)
+    ) {
+        sortOptions.forEach { option ->
+            DropdownMenuItem(
+                text = { Text(option.label) },
+                onClick = {
+                    appListViewModel.sortedBy = option
+                    onDismiss()
+                },
+                trailingIcon = {
+                    if (appListViewModel.sortedBy == option) {
+                        Icon(
+                            Icons.Default.Check,
+                            contentDescription = null
+                        )
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/io/github/samolego/canta/ui/menu/SortByOptions.kt
+++ b/app/src/main/java/io/github/samolego/canta/ui/menu/SortByOptions.kt
@@ -21,8 +21,8 @@ data class SortOption(
 enum class SortField {
     NAME,
     PACKAGE_NAME,
-    VERSION,
-    SIZE
+    SIZE,
+    BADGE
 }
 
 enum class SortDirection {
@@ -37,8 +37,8 @@ val sortOptions = listOf(
     SortOption(SortField.PACKAGE_NAME, SortDirection.DESCENDING, "Package: Z → A"),
     SortOption(SortField.SIZE, SortDirection.ASCENDING, "Size: Low → High"),
     SortOption(SortField.SIZE, SortDirection.DESCENDING, "Size: High → Low"),
-    SortOption(SortField.VERSION, SortDirection.ASCENDING, "Version: Low → High"),
-    SortOption(SortField.VERSION, SortDirection.DESCENDING, "Version: High → Low")
+    SortOption(SortField.BADGE, SortDirection.ASCENDING, "Badge: Recommended → System"),
+    SortOption(SortField.BADGE, SortDirection.DESCENDING, "Badge: System → Recommended")
 )
 
 @Composable

--- a/app/src/main/java/io/github/samolego/canta/ui/viewmodel/AppListViewModel.kt
+++ b/app/src/main/java/io/github/samolego/canta/ui/viewmodel/AppListViewModel.kt
@@ -13,6 +13,9 @@ import io.github.samolego.canta.data.SettingsStore
 import io.github.samolego.canta.extension.getAllPackagesInfo
 import io.github.samolego.canta.extension.mutableStateSetOf
 import io.github.samolego.canta.packageName
+import io.github.samolego.canta.ui.menu.SortDirection
+import io.github.samolego.canta.ui.menu.SortField
+import io.github.samolego.canta.ui.menu.SortOption
 import io.github.samolego.canta.util.BloatData
 import io.github.samolego.canta.util.BloatUtils
 import io.github.samolego.canta.util.LogUtils
@@ -43,6 +46,13 @@ class AppListViewModel : ViewModel() {
 
     var selectedFilter by mutableStateOf(Filter.any)
 
+    var sortedBy by mutableStateOf(
+        SortOption(
+            field = SortField.NAME,
+            direction = SortDirection.ASCENDING,
+            "Name: A → Z"
+        )
+    )
     val selectedAppsSorted by derivedStateOf {
         sortedList.filter { selectedApps.contains(it.packageName) }
     }
@@ -51,7 +61,23 @@ class AppListViewModel : ViewModel() {
     private val sortedList by derivedStateOf {
         isLoading = true
 
-        apps.filter { selectedFilter.shouldShow(it) }.sortedWith(nameComparator).also {
+        val filteredApps = apps.filter { selectedFilter.shouldShow(it) }
+
+        val comparator = when (sortedBy.field) {
+            SortField.NAME -> nameComparator
+            SortField.PACKAGE_NAME -> compareBy(AppInfo::packageName)
+            SortField.VERSION -> compareBy(AppInfo::versionCode)
+            SortField.SIZE -> compareBy(AppInfo::size)
+        }
+
+        val finalComparator =
+            if (sortedBy.direction == SortDirection.ASCENDING) {
+                comparator
+            } else {
+                comparator.reversed()
+            }
+
+        filteredApps.sortedWith(finalComparator).also {
             isLoading = false
         }
     }

--- a/app/src/main/java/io/github/samolego/canta/ui/viewmodel/AppListViewModel.kt
+++ b/app/src/main/java/io/github/samolego/canta/ui/viewmodel/AppListViewModel.kt
@@ -19,6 +19,7 @@ import io.github.samolego.canta.ui.menu.SortOption
 import io.github.samolego.canta.util.BloatData
 import io.github.samolego.canta.util.BloatUtils
 import io.github.samolego.canta.util.LogUtils
+import io.github.samolego.canta.util.RemovalRecommendation
 import io.github.samolego.canta.util.apps.AppInfo
 import io.github.samolego.canta.util.apps.Filter
 import kotlinx.coroutines.Dispatchers
@@ -66,8 +67,10 @@ class AppListViewModel : ViewModel() {
         val comparator = when (sortedBy.field) {
             SortField.NAME -> nameComparator
             SortField.PACKAGE_NAME -> compareBy(AppInfo::packageName)
-            SortField.VERSION -> compareBy(AppInfo::versionCode)
             SortField.SIZE -> compareBy(AppInfo::size)
+            SortField.BADGE -> compareBy {
+                getRecommendationRank(it.removalInfo)
+            }
         }
 
         val finalComparator =
@@ -203,6 +206,20 @@ class AppListViewModel : ViewModel() {
                         it
                     }
                 }
+    }
+
+
+    private fun getRecommendationRank(
+        recommendation: RemovalRecommendation?
+    ): Int {
+        return when (recommendation) {
+            RemovalRecommendation.RECOMMENDED -> 0
+            RemovalRecommendation.ADVANCED -> 1
+            RemovalRecommendation.EXPERT -> 2
+            RemovalRecommendation.UNSAFE -> 3
+            RemovalRecommendation.SYSTEM -> 4
+            null -> 5
+        }
     }
 }
 

--- a/app/src/main/java/io/github/samolego/canta/util/apps/AppInfo.kt
+++ b/app/src/main/java/io/github/samolego/canta/util/apps/AppInfo.kt
@@ -7,6 +7,7 @@ import android.os.Parcelable
 import io.github.samolego.canta.util.BloatData
 import io.github.samolego.canta.util.RemovalRecommendation
 import kotlinx.parcelize.Parcelize
+import java.io.File
 
 /**
  * Data class to hold information about an app.
@@ -17,6 +18,7 @@ data class AppInfo(
     val packageName: String,
     val versionName: String,
     val versionCode: Long,
+    val size: Long = 0,
     val isSystemApp: Boolean,
     val isUninstalled: Boolean,
     val isDisabled: Boolean,
@@ -55,6 +57,7 @@ data class AppInfo(
                 appName = packageInfo.applicationInfo!!.loadLabel(packageManager).toString(),
                 packageName = packageInfo.packageName,
                 versionName = versionName,
+                size = File(packageInfo.applicationInfo!!.sourceDir).length(),
                 versionCode = packageInfo.longVersionCode,
                 isSystemApp = isSystemApp,
                 isUninstalled = isUninstalled,

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Sorteer volgens</string>
+    <string name="sort_name_ascending">Naam: A -&gt; Z</string>
+    <string name="sort_name_descending">Naam: Z -&gt; A</string>
+    <string name="sort_package_ascending">Pakket: A -&gt; Z</string>
+    <string name="sort_package_descending">Pakket: Z -&gt; A</string>
+    <string name="sort_size_ascending">Grootte: Klein -&gt; Groot</string>
+    <string name="sort_size_descending">Grootte: Groot -&gt; Klein</string>
+    <string name="sort_badge_ascending">Kenteken: Aanbeveel -&gt; Stelsel</string>
+    <string name="sort_badge_descending">Kenteken: Stelsel -&gt; Aanbeveel</string>
 </resources>
+

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">إلغاء</string>
     <string name="ok">موافق</string>
@@ -129,4 +129,14 @@
     <string name="require_auth_setting_desc">تطلب الاستيثاق لإلغاء تثبيت التطبيقات أو إعادة تثبيتها.</string>
     <string name="require_auth_setting">تطلب استيثاق</string>
     <string name="enable_usb_debugging">(اختياري) فعّل تصحيح علل USB</string>
+    <string name="sort_by">فرز حسب</string>
+    <string name="sort_name_ascending">الاسم: أ -&gt; ي</string>
+    <string name="sort_name_descending">الاسم: ي -&gt; أ</string>
+    <string name="sort_package_ascending">الحزمة: أ -&gt; ي</string>
+    <string name="sort_package_descending">الحزمة: ي -&gt; أ</string>
+    <string name="sort_size_ascending">الحجم: من الأصغر إلى الأكبر</string>
+    <string name="sort_size_descending">الحجم: من الأكبر إلى الأصغر</string>
+    <string name="sort_badge_ascending">الشارة: موصى به -&gt; النظام</string>
+    <string name="sort_badge_descending">الشارة: النظام -&gt; موصى به</string>
 </resources>
+

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">বাতিল</string>
     <string name="ok">ঠিক আছে</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(ঐচ্ছিক) ইউ. এস. বি. ডিবাগিং চালু করুন</string>
+    <string name="sort_by">সাজান</string>
+    <string name="sort_name_ascending">নাম: A -&gt; Z</string>
+    <string name="sort_name_descending">নাম: Z -&gt; A</string>
+    <string name="sort_package_ascending">প্যাকেজ: A -&gt; Z</string>
+    <string name="sort_package_descending">প্যাকেজ: Z -&gt; A</string>
+    <string name="sort_size_ascending">আকার: ছোট -&gt; বড়</string>
+    <string name="sort_size_descending">আকার: বড় -&gt; ছোট</string>
+    <string name="sort_badge_ascending">ব্যাজ: প্রস্তাবিত -&gt; সিস্টেম</string>
+    <string name="sort_badge_descending">ব্যাজ: সিস্টেম -&gt; প্রস্তাবিত</string>
 </resources>
+

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancel·la</string>
     <string name="ok">D\'acord</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Ordena per</string>
+    <string name="sort_name_ascending">Nom: A -&gt; Z</string>
+    <string name="sort_name_descending">Nom: Z -&gt; A</string>
+    <string name="sort_package_ascending">Paquet: A -&gt; Z</string>
+    <string name="sort_package_descending">Paquet: Z -&gt; A</string>
+    <string name="sort_size_ascending">Mida: Petita -&gt; Gran</string>
+    <string name="sort_size_descending">Mida: Gran -&gt; Petita</string>
+    <string name="sort_badge_ascending">Insígnia: Recomanat -&gt; Sistema</string>
+    <string name="sort_badge_descending">Insígnia: Sistema -&gt; Recomanat</string>
 </resources>
+

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Zrušit</string>
     <string name="ok">OK</string>
@@ -121,4 +121,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Řadit podle</string>
+    <string name="sort_name_ascending">Název: A -&gt; Z</string>
+    <string name="sort_name_descending">Název: Z -&gt; A</string>
+    <string name="sort_package_ascending">Balíček: A -&gt; Z</string>
+    <string name="sort_package_descending">Balíček: Z -&gt; A</string>
+    <string name="sort_size_ascending">Velikost: Malá -&gt; Velká</string>
+    <string name="sort_size_descending">Velikost: Velká -&gt; Malá</string>
+    <string name="sort_badge_ascending">Štítek: Doporučené -&gt; Systém</string>
+    <string name="sort_badge_descending">Štítek: Systém -&gt; Doporučené</string>
 </resources>
+

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Afbryd</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Kræv godkendelse for at afinstallere/geninstallere apps.</string>
     <string name="require_auth_setting">Kræv godkendelse</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Sortér efter</string>
+    <string name="sort_name_ascending">Navn: A -&gt; Z</string>
+    <string name="sort_name_descending">Navn: Z -&gt; A</string>
+    <string name="sort_package_ascending">Pakke: A -&gt; Z</string>
+    <string name="sort_package_descending">Pakke: Z -&gt; A</string>
+    <string name="sort_size_ascending">Størrelse: Lille -&gt; Stor</string>
+    <string name="sort_size_descending">Størrelse: Stor -&gt; Lille</string>
+    <string name="sort_badge_ascending">Mærke: Anbefalet -&gt; System</string>
+    <string name="sort_badge_descending">Mærke: System -&gt; Anbefalet</string>
 </resources>
+

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Abbrechen</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Sortieren nach</string>
+    <string name="sort_name_ascending">Name: A -&gt; Z</string>
+    <string name="sort_name_descending">Name: Z -&gt; A</string>
+    <string name="sort_package_ascending">Paket: A -&gt; Z</string>
+    <string name="sort_package_descending">Paket: Z -&gt; A</string>
+    <string name="sort_size_ascending">Größe: Klein -&gt; Groß</string>
+    <string name="sort_size_descending">Größe: Groß -&gt; Klein</string>
+    <string name="sort_badge_ascending">Kennzeichnung: Empfohlen -&gt; System</string>
+    <string name="sort_badge_descending">Kennzeichnung: System -&gt; Empfohlen</string>
 </resources>
+

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Ακύρωση</string>
     <string name="ok">ΟΚ</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Ταξινόμηση κατά</string>
+    <string name="sort_name_ascending">Όνομα: A -&gt; Z</string>
+    <string name="sort_name_descending">Όνομα: Z -&gt; A</string>
+    <string name="sort_package_ascending">Πακέτο: A -&gt; Z</string>
+    <string name="sort_package_descending">Πακέτο: Z -&gt; A</string>
+    <string name="sort_size_ascending">Μέγεθος: Μικρό -&gt; Μεγάλο</string>
+    <string name="sort_size_descending">Μέγεθος: Μεγάλο -&gt; Μικρό</string>
+    <string name="sort_badge_ascending">Σήμα: Προτεινόμενο -&gt; Σύστημα</string>
+    <string name="sort_badge_descending">Σήμα: Σύστημα -&gt; Προτεινόμενο</string>
 </resources>
+

--- a/app/src/main/res/values-en-rPT/strings.xml
+++ b/app/src/main/res/values-en-rPT/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Ordenar por</string>
+    <string name="sort_name_ascending">Nome: A -&gt; Z</string>
+    <string name="sort_name_descending">Nome: Z -&gt; A</string>
+    <string name="sort_package_ascending">Pacote: A -&gt; Z</string>
+    <string name="sort_package_descending">Pacote: Z -&gt; A</string>
+    <string name="sort_size_ascending">Tamanho: Pequeno -&gt; Grande</string>
+    <string name="sort_size_descending">Tamanho: Grande -&gt; Pequeno</string>
+    <string name="sort_badge_ascending">Distintivo: Recomendado -&gt; Sistema</string>
+    <string name="sort_badge_descending">Distintivo: Sistema -&gt; Recomendado</string>
 </resources>
+

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancelar</string>
     <string name="ok">Aceptar</string>
@@ -114,4 +114,14 @@ Pega aquí el JSON del preajuste ...</string>
     <string name="require_auth_setting_desc">Requerir autenticación para desinstalar o reinstalar aplicaciones.</string>
     <string name="require_auth_setting">Requerir autenticación</string>
     <string name="enable_usb_debugging">(Opcional) Activar la depuración USB</string>
+    <string name="sort_by">Ordenar por</string>
+    <string name="sort_name_ascending">Nombre: A -&gt; Z</string>
+    <string name="sort_name_descending">Nombre: Z -&gt; A</string>
+    <string name="sort_package_ascending">Paquete: A -&gt; Z</string>
+    <string name="sort_package_descending">Paquete: Z -&gt; A</string>
+    <string name="sort_size_ascending">Tamaño: Pequeño -&gt; Grande</string>
+    <string name="sort_size_descending">Tamaño: Grande -&gt; Pequeño</string>
+    <string name="sort_badge_ascending">Insignia: Recomendado -&gt; Sistema</string>
+    <string name="sort_badge_descending">Insignia: Sistema -&gt; Recomendado</string>
 </resources>
+

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <resources>
     <string name="install_shizuku">Install Shizuku app</string>
     <string name="start_shizuku_service">Start Shizuku service</string>
@@ -103,4 +103,14 @@
     <item quantity="one">You have successfully reinstalled %d app!</item>
     <item quantity="other">You have successfully reinstalled %d apps!</item>
 </plurals>
+    <string name="sort_by">مرتب‌سازی بر اساس</string>
+    <string name="sort_name_ascending">نام: A -&gt; Z</string>
+    <string name="sort_name_descending">نام: Z -&gt; A</string>
+    <string name="sort_package_ascending">بسته: A -&gt; Z</string>
+    <string name="sort_package_descending">بسته: Z -&gt; A</string>
+    <string name="sort_size_ascending">اندازه: کوچک -&gt; بزرگ</string>
+    <string name="sort_size_descending">اندازه: بزرگ -&gt; کوچک</string>
+    <string name="sort_badge_ascending">نشان: پیشنهادی -&gt; سیستم</string>
+    <string name="sort_badge_descending">نشان: سیستم -&gt; پیشنهادی</string>
 </resources>
+

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Peruuta</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Vaadi todennusta sovellusten poistamiseen tai uudelleenasentamiseen.</string>
     <string name="require_auth_setting">Vaadi todennusta</string>
     <string name="enable_usb_debugging">(Valinnainen) Ota USB-vianetsintä käyttöön</string>
+    <string name="sort_by">Järjestä</string>
+    <string name="sort_name_ascending">Nimi: A -&gt; Z</string>
+    <string name="sort_name_descending">Nimi: Z -&gt; A</string>
+    <string name="sort_package_ascending">Paketti: A -&gt; Z</string>
+    <string name="sort_package_descending">Paketti: Z -&gt; A</string>
+    <string name="sort_size_ascending">Koko: Pieni -&gt; Suuri</string>
+    <string name="sort_size_descending">Koko: Suuri -&gt; Pieni</string>
+    <string name="sort_badge_ascending">Tunniste: Suositeltu -&gt; Järjestelmä</string>
+    <string name="sort_badge_descending">Tunniste: Järjestelmä -&gt; Suositeltu</string>
 </resources>
+

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Annuler</string>
     <string name="ok">Ok</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Authentification requise pour désinstaller ou réinstaller des applications.</string>
     <string name="require_auth_setting">Exiger une authentification</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Trier par</string>
+    <string name="sort_name_ascending">Nom : A -&gt; Z</string>
+    <string name="sort_name_descending">Nom : Z -&gt; A</string>
+    <string name="sort_package_ascending">Paquet : A -&gt; Z</string>
+    <string name="sort_package_descending">Paquet : Z -&gt; A</string>
+    <string name="sort_size_ascending">Taille : Petite -&gt; Grande</string>
+    <string name="sort_size_descending">Taille : Grande -&gt; Petite</string>
+    <string name="sort_badge_ascending">Badge : Recommandé -&gt; Système</string>
+    <string name="sort_badge_descending">Badge : Système -&gt; Recommandé</string>
 </resources>
+

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <resources>
     <string name="cancel">ביטול</string>
     <string name="ok">בסדר</string>
@@ -157,4 +157,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">מיון לפי</string>
+    <string name="sort_name_ascending">שם: A -&gt; Z</string>
+    <string name="sort_name_descending">שם: Z -&gt; A</string>
+    <string name="sort_package_ascending">חבילה: A -&gt; Z</string>
+    <string name="sort_package_descending">חבילה: Z -&gt; A</string>
+    <string name="sort_size_ascending">גודל: קטן -&gt; גדול</string>
+    <string name="sort_size_descending">גודל: גדול -&gt; קטן</string>
+    <string name="sort_badge_ascending">תג: מומלץ -&gt; מערכת</string>
+    <string name="sort_badge_descending">תג: מערכת -&gt; מומלץ</string>
 </resources>
+

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">रद्द करें</string>
     <string name="ok">ठीक है</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">इसके अनुसार क्रमित करें</string>
+    <string name="sort_name_ascending">नाम: A -&gt; Z</string>
+    <string name="sort_name_descending">नाम: Z -&gt; A</string>
+    <string name="sort_package_ascending">पैकेज: A -&gt; Z</string>
+    <string name="sort_package_descending">पैकेज: Z -&gt; A</string>
+    <string name="sort_size_ascending">आकार: छोटा -&gt; बड़ा</string>
+    <string name="sort_size_descending">आकार: बड़ा -&gt; छोटा</string>
+    <string name="sort_badge_ascending">बैज: अनुशंसित -&gt; सिस्टम</string>
+    <string name="sort_badge_descending">बैज: सिस्टम -&gt; अनुशंसित</string>
 </resources>
+

--- a/app/src/main/res/values-hr-rHR/strings.xml
+++ b/app/src/main/res/values-hr-rHR/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Odustani</string>
     <string name="ok">OK</string>
@@ -117,4 +117,14 @@
     <string name="require_auth_setting_desc">Zahtijevajte autentifikaciju za deinstalaciju ili ponovnu instalaciju aplikacija.</string>
     <string name="require_auth_setting">Zahtijevaj autentifikaciju</string>
     <string name="enable_usb_debugging">(Neobavezno) Omogući otklanjanje pogrešaka putem USB-a</string>
+    <string name="sort_by">Razvrstaj po</string>
+    <string name="sort_name_ascending">Naziv: A -&gt; Z</string>
+    <string name="sort_name_descending">Naziv: Z -&gt; A</string>
+    <string name="sort_package_ascending">Paket: A -&gt; Z</string>
+    <string name="sort_package_descending">Paket: Z -&gt; A</string>
+    <string name="sort_size_ascending">Veličina: Mala -&gt; Velika</string>
+    <string name="sort_size_descending">Veličina: Velika -&gt; Mala</string>
+    <string name="sort_badge_ascending">Oznaka: Preporučeno -&gt; Sustav</string>
+    <string name="sort_badge_descending">Oznaka: Sustav -&gt; Preporučeno</string>
 </resources>
+

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Mégse</string>
     <string name="ok">Rendben</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Azonosítás szükséges</string>
     <string name="enable_usb_debugging">(Opcionális) Az USB hibakeresés engedélyezése</string>
+    <string name="sort_by">Rendezés</string>
+    <string name="sort_name_ascending">Név: A -&gt; Z</string>
+    <string name="sort_name_descending">Név: Z -&gt; A</string>
+    <string name="sort_package_ascending">Csomag: A -&gt; Z</string>
+    <string name="sort_package_descending">Csomag: Z -&gt; A</string>
+    <string name="sort_size_ascending">Méret: Kicsi -&gt; Nagy</string>
+    <string name="sort_size_descending">Méret: Nagy -&gt; Kicsi</string>
+    <string name="sort_badge_ascending">Jelvény: Ajánlott -&gt; Rendszer</string>
+    <string name="sort_badge_descending">Jelvény: Rendszer -&gt; Ajánlott</string>
 </resources>
+

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Annulla</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Ordina per</string>
+    <string name="sort_name_ascending">Nome: A -&gt; Z</string>
+    <string name="sort_name_descending">Nome: Z -&gt; A</string>
+    <string name="sort_package_ascending">Pacchetto: A -&gt; Z</string>
+    <string name="sort_package_descending">Pacchetto: Z -&gt; A</string>
+    <string name="sort_size_ascending">Dimensione: Piccola -&gt; Grande</string>
+    <string name="sort_size_descending">Dimensione: Grande -&gt; Piccola</string>
+    <string name="sort_badge_ascending">Badge: Consigliato -&gt; Sistema</string>
+    <string name="sort_badge_descending">Badge: Sistema -&gt; Consigliato</string>
 </resources>
+

--- a/app/src/main/res/values-iw-rIL/strings.xml
+++ b/app/src/main/res/values-iw-rIL/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">ביטול</string>
     <string name="ok">אישור</string>
@@ -121,4 +121,14 @@
     <string name="require_auth_setting_desc">נדרש אימות לצורך הסרה או התקנה מחדש של יישומים.</string>
     <string name="require_auth_setting">דרישת אימות</string>
     <string name="enable_usb_debugging">הפעלת ניפוי שגיאות ב־USB (רשות)</string>
+    <string name="sort_by">מיון לפי</string>
+    <string name="sort_name_ascending">שם: A -&gt; Z</string>
+    <string name="sort_name_descending">שם: Z -&gt; A</string>
+    <string name="sort_package_ascending">חבילה: A -&gt; Z</string>
+    <string name="sort_package_descending">חבילה: Z -&gt; A</string>
+    <string name="sort_size_ascending">גודל: קטן -&gt; גדול</string>
+    <string name="sort_size_descending">גודל: גדול -&gt; קטן</string>
+    <string name="sort_badge_ascending">תג: מומלץ -&gt; מערכת</string>
+    <string name="sort_badge_descending">תג: מערכת -&gt; מומלץ</string>
 </resources>
+

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">キャンセル</string>
     <string name="ok">OK</string>
@@ -109,4 +109,14 @@
     <string name="require_auth_setting_desc">アプリをアンインストールまたは再インストールするには認証が必要です。</string>
     <string name="require_auth_setting">認証を要求</string>
     <string name="enable_usb_debugging">（任意）USBデバッグを有効にする</string>
+    <string name="sort_by">並べ替え</string>
+    <string name="sort_name_ascending">名前: A -&gt; Z</string>
+    <string name="sort_name_descending">名前: Z -&gt; A</string>
+    <string name="sort_package_ascending">パッケージ: A -&gt; Z</string>
+    <string name="sort_package_descending">パッケージ: Z -&gt; A</string>
+    <string name="sort_size_ascending">サイズ: 小さい -&gt; 大きい</string>
+    <string name="sort_size_descending">サイズ: 大きい -&gt; 小さい</string>
+    <string name="sort_badge_ascending">バッジ: 推奨 -&gt; システム</string>
+    <string name="sort_badge_descending">バッジ: システム -&gt; 推奨</string>
 </resources>
+

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel"></string>
     <string name="ok">OK</string>
@@ -109,4 +109,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">정렬 기준</string>
+    <string name="sort_name_ascending">이름: A -&gt; Z</string>
+    <string name="sort_name_descending">이름: Z -&gt; A</string>
+    <string name="sort_package_ascending">패키지: A -&gt; Z</string>
+    <string name="sort_package_descending">패키지: Z -&gt; A</string>
+    <string name="sort_size_ascending">크기: 작음 -&gt; 큼</string>
+    <string name="sort_size_descending">크기: 큼 -&gt; 작음</string>
+    <string name="sort_badge_ascending">배지: 권장 -&gt; 시스템</string>
+    <string name="sort_badge_descending">배지: 시스템 -&gt; 권장</string>
 </resources>
+

--- a/app/src/main/res/values-ks-rIN/strings.xml
+++ b/app/src/main/res/values-ks-rIN/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">ترتیب دِیو</string>
+    <string name="sort_name_ascending">ناو: A -&gt; Z</string>
+    <string name="sort_name_descending">ناو: Z -&gt; A</string>
+    <string name="sort_package_ascending">پیکیج: A -&gt; Z</string>
+    <string name="sort_package_descending">پیکیج: Z -&gt; A</string>
+    <string name="sort_size_ascending">سائز: چھوٹا -&gt; بڑا</string>
+    <string name="sort_size_descending">سائز: بڑا -&gt; چھوٹا</string>
+    <string name="sort_badge_ascending">بیج: سفارش کردہ -&gt; سسٹم</string>
+    <string name="sort_badge_descending">بیج: سسٹم -&gt; سفارش کردہ</string>
 </resources>
+

--- a/app/src/main/res/values-lv-rLV/strings.xml
+++ b/app/src/main/res/values-lv-rLV/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Atcelt</string>
     <string name="ok">Labi</string>
@@ -117,4 +117,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Pēc izvēles) Iespējot USB atkļūdošanu</string>
+    <string name="sort_by">Kārtot pēc</string>
+    <string name="sort_name_ascending">Nosaukums: A -&gt; Z</string>
+    <string name="sort_name_descending">Nosaukums: Z -&gt; A</string>
+    <string name="sort_package_ascending">Pakotne: A -&gt; Z</string>
+    <string name="sort_package_descending">Pakotne: Z -&gt; A</string>
+    <string name="sort_size_ascending">Izmērs: Mazs -&gt; Liels</string>
+    <string name="sort_size_descending">Izmērs: Liels -&gt; Mazs</string>
+    <string name="sort_badge_ascending">Emblēma: Ieteicams -&gt; Sistēma</string>
+    <string name="sort_badge_descending">Emblēma: Sistēma -&gt; Ieteicams</string>
 </resources>
+

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Эрэмбэлэх</string>
+    <string name="sort_name_ascending">Нэр: A -&gt; Z</string>
+    <string name="sort_name_descending">Нэр: Z -&gt; A</string>
+    <string name="sort_package_ascending">Багц: A -&gt; Z</string>
+    <string name="sort_package_descending">Багц: Z -&gt; A</string>
+    <string name="sort_size_ascending">Хэмжээ: Жижиг -&gt; Том</string>
+    <string name="sort_size_descending">Хэмжээ: Том -&gt; Жижиг</string>
+    <string name="sort_badge_ascending">Тэмдэг: Санал болгосон -&gt; Систем</string>
+    <string name="sort_badge_descending">Тэмдэг: Систем -&gt; Санал болгосон</string>
 </resources>
+

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">यसअनुसार क्रमबद्ध गर्नुहोस्</string>
+    <string name="sort_name_ascending">नाम: A -&gt; Z</string>
+    <string name="sort_name_descending">नाम: Z -&gt; A</string>
+    <string name="sort_package_ascending">प्याकेज: A -&gt; Z</string>
+    <string name="sort_package_descending">प्याकेज: Z -&gt; A</string>
+    <string name="sort_size_ascending">आकार: सानो -&gt; ठूलो</string>
+    <string name="sort_size_descending">आकार: ठूलो -&gt; सानो</string>
+    <string name="sort_badge_ascending">ब्याज: सिफारिस गरिएको -&gt; प्रणाली</string>
+    <string name="sort_badge_descending">ब्याज: प्रणाली -&gt; सिफारिस गरिएको</string>
 </resources>
+

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Annuleer</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Authenticatie vereist om apps te verwijderen of opnieuw te installeren.</string>
     <string name="require_auth_setting">Verificatie vereist</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Sorteren op</string>
+    <string name="sort_name_ascending">Naam: A -&gt; Z</string>
+    <string name="sort_name_descending">Naam: Z -&gt; A</string>
+    <string name="sort_package_ascending">Pakket: A -&gt; Z</string>
+    <string name="sort_package_descending">Pakket: Z -&gt; A</string>
+    <string name="sort_size_ascending">Grootte: Klein -&gt; Groot</string>
+    <string name="sort_size_descending">Grootte: Groot -&gt; Klein</string>
+    <string name="sort_badge_ascending">Badge: Aanbevolen -&gt; Systeem</string>
+    <string name="sort_badge_descending">Badge: Systeem -&gt; Aanbevolen</string>
 </resources>
+

--- a/app/src/main/res/values-no-rNO/strings.xml
+++ b/app/src/main/res/values-no-rNO/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_name_ascending">Name: A → Z</string>
+    <string name="sort_name_descending">Name: Z → A</string>
+    <string name="sort_package_ascending">Package: A → Z</string>
+    <string name="sort_package_descending">Package: Z → A</string>
+    <string name="sort_size_ascending">Size: Low → High</string>
+    <string name="sort_size_descending">Size: High → Low</string>
+    <string name="sort_badge_ascending">Badge: Recommended → System</string>
+    <string name="sort_badge_descending">Badge: System → Recommended</string>
+    <string name="sort_by">Sorter etter</string>
 </resources>
+

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Anuluj</string>
     <string name="ok">OK</string>
@@ -121,4 +121,14 @@
     <string name="require_auth_setting_desc">Wymagaj uwierzytelnienia przy odinstalowywaniu i instalacji aplikacji.</string>
     <string name="require_auth_setting">Wymagaj uwierzytelniania</string>
     <string name="enable_usb_debugging">Włącz debugowanie USB (opcjonalnie)</string>
+    <string name="sort_by">Sortuj według</string>
+    <string name="sort_name_ascending">Nazwa: A -&gt; Z</string>
+    <string name="sort_name_descending">Nazwa: Z -&gt; A</string>
+    <string name="sort_package_ascending">Pakiet: A -&gt; Z</string>
+    <string name="sort_package_descending">Pakiet: Z -&gt; A</string>
+    <string name="sort_size_ascending">Rozmiar: Mały -&gt; Duży</string>
+    <string name="sort_size_descending">Rozmiar: Duży -&gt; Mały</string>
+    <string name="sort_badge_ascending">Odznaka: Zalecane -&gt; System</string>
+    <string name="sort_badge_descending">Odznaka: System -&gt; Zalecane</string>
 </resources>
+

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancelar</string>
     <string name="ok">Ok</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Exigir autenticação para desinstalar ou reinstalar aplicativos.</string>
     <string name="require_auth_setting">Requer autenticação</string>
     <string name="enable_usb_debugging">(Opcional) Ative Depuração USB</string>
+    <string name="sort_by">Ordenar por</string>
+    <string name="sort_name_ascending">Nome: A -&gt; Z</string>
+    <string name="sort_name_descending">Nome: Z -&gt; A</string>
+    <string name="sort_package_ascending">Pacote: A -&gt; Z</string>
+    <string name="sort_package_descending">Pacote: Z -&gt; A</string>
+    <string name="sort_size_ascending">Tamanho: Pequeno -&gt; Grande</string>
+    <string name="sort_size_descending">Tamanho: Grande -&gt; Pequeno</string>
+    <string name="sort_badge_ascending">Emblema: Recomendado -&gt; Sistema</string>
+    <string name="sort_badge_descending">Emblema: Sistema -&gt; Recomendado</string>
 </resources>
+

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancelar</string>
     <string name="ok">Ok</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Requer autenticação para desinstalar ou reinstalar aplicativos.</string>
     <string name="require_auth_setting">Requer Autenticação</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Ordenar por</string>
+    <string name="sort_name_ascending">Nome: A -&gt; Z</string>
+    <string name="sort_name_descending">Nome: Z -&gt; A</string>
+    <string name="sort_package_ascending">Pacote: A -&gt; Z</string>
+    <string name="sort_package_descending">Pacote: Z -&gt; A</string>
+    <string name="sort_size_ascending">Tamanho: Pequeno -&gt; Grande</string>
+    <string name="sort_size_descending">Tamanho: Grande -&gt; Pequeno</string>
+    <string name="sort_badge_ascending">Emblema: Recomendado -&gt; Sistema</string>
+    <string name="sort_badge_descending">Emblema: Sistema -&gt; Recomendado</string>
 </resources>
+

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Anulați</string>
     <string name="ok">OK</string>
@@ -117,4 +117,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Sortează după</string>
+    <string name="sort_name_ascending">Nume: A -&gt; Z</string>
+    <string name="sort_name_descending">Nume: Z -&gt; A</string>
+    <string name="sort_package_ascending">Pachet: A -&gt; Z</string>
+    <string name="sort_package_descending">Pachet: Z -&gt; A</string>
+    <string name="sort_size_ascending">Dimensiune: Mic -&gt; Mare</string>
+    <string name="sort_size_descending">Dimensiune: Mare -&gt; Mic</string>
+    <string name="sort_badge_ascending">Insignă: Recomandat -&gt; Sistem</string>
+    <string name="sort_badge_descending">Insignă: Sistem -&gt; Recomandat</string>
 </resources>
+

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Отмена</string>
     <string name="ok">ОК</string>
@@ -121,4 +121,14 @@
     <string name="require_auth_setting_desc">Для удаления или переустановки приложений требуется аутентификация.</string>
     <string name="require_auth_setting">Требуется проверка</string>
     <string name="enable_usb_debugging">(Необязательно) Включить USB отладку</string>
+    <string name="sort_by">Сортировать по</string>
+    <string name="sort_name_ascending">Имя: A -&gt; Z</string>
+    <string name="sort_name_descending">Имя: Z -&gt; A</string>
+    <string name="sort_package_ascending">Пакет: A -&gt; Z</string>
+    <string name="sort_package_descending">Пакет: Z -&gt; A</string>
+    <string name="sort_size_ascending">Размер: Маленький -&gt; Большой</string>
+    <string name="sort_size_descending">Размер: Большой -&gt; Маленький</string>
+    <string name="sort_badge_ascending">Значок: Рекомендуется -&gt; Система</string>
+    <string name="sort_badge_descending">Значок: Система -&gt; Рекомендуется</string>
 </resources>
+

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
@@ -121,4 +121,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Zoradiť podľa</string>
+    <string name="sort_name_ascending">Názov: A -&gt; Z</string>
+    <string name="sort_name_descending">Názov: Z -&gt; A</string>
+    <string name="sort_package_ascending">Balík: A -&gt; Z</string>
+    <string name="sort_package_descending">Balík: Z -&gt; A</string>
+    <string name="sort_size_ascending">Veľkosť: Malá -&gt; Veľká</string>
+    <string name="sort_size_descending">Veľkosť: Veľká -&gt; Malá</string>
+    <string name="sort_badge_ascending">Štítok: Odporúčané -&gt; Systém</string>
+    <string name="sort_badge_descending">Štítok: Systém -&gt; Odporúčané</string>
 </resources>
+

--- a/app/src/main/res/values-sl-rSI/strings.xml
+++ b/app/src/main/res/values-sl-rSI/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Prekliči</string>
     <string name="ok">V redu</string>
@@ -121,4 +121,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Razvrsti po</string>
+    <string name="sort_name_ascending">Ime: A -&gt; Z</string>
+    <string name="sort_name_descending">Ime: Z -&gt; A</string>
+    <string name="sort_package_ascending">Paket: A -&gt; Z</string>
+    <string name="sort_package_descending">Paket: Z -&gt; A</string>
+    <string name="sort_size_ascending">Velikost: Majhna -&gt; Velika</string>
+    <string name="sort_size_descending">Velikost: Velika -&gt; Majhna</string>
+    <string name="sort_badge_ascending">Značka: Priporočeno -&gt; Sistem</string>
+    <string name="sort_badge_descending">Značka: Sistem -&gt; Priporočeno</string>
 </resources>
+

--- a/app/src/main/res/values-so-rSO/strings.xml
+++ b/app/src/main/res/values-so-rSO/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Ku kala saar</string>
+    <string name="sort_name_ascending">Magac: A -&gt; Z</string>
+    <string name="sort_name_descending">Magac: Z -&gt; A</string>
+    <string name="sort_package_ascending">Xirmo: A -&gt; Z</string>
+    <string name="sort_package_descending">Xirmo: Z -&gt; A</string>
+    <string name="sort_size_ascending">Cabbir: Yar -&gt; Weyn</string>
+    <string name="sort_size_descending">Cabbir: Weyn -&gt; Yar</string>
+    <string name="sort_badge_ascending">Calaamad: Lagu taliyay -&gt; Nidaam</string>
+    <string name="sort_badge_descending">Calaamad: Nidaam -&gt; Lagu taliyay</string>
 </resources>
+

--- a/app/src/main/res/values-sr-rSP/strings.xml
+++ b/app/src/main/res/values-sr-rSP/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Откажи</string>
     <string name="ok">Ок</string>
@@ -117,4 +117,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Сортирај по</string>
+    <string name="sort_name_ascending">Назив: A -&gt; Z</string>
+    <string name="sort_name_descending">Назив: Z -&gt; A</string>
+    <string name="sort_package_ascending">Пакет: A -&gt; Z</string>
+    <string name="sort_package_descending">Пакет: Z -&gt; A</string>
+    <string name="sort_size_ascending">Величина: Мала -&gt; Велика</string>
+    <string name="sort_size_descending">Величина: Велика -&gt; Мала</string>
+    <string name="sort_badge_ascending">Ознака: Препоручено -&gt; Систем</string>
+    <string name="sort_badge_descending">Ознака: Систем -&gt; Препоручено</string>
 </resources>
+

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Sortera efter</string>
+    <string name="sort_name_ascending">Namn: A -&gt; Z</string>
+    <string name="sort_name_descending">Namn: Z -&gt; A</string>
+    <string name="sort_package_ascending">Paket: A -&gt; Z</string>
+    <string name="sort_package_descending">Paket: Z -&gt; A</string>
+    <string name="sort_size_ascending">Storlek: Liten -&gt; Stor</string>
+    <string name="sort_size_descending">Storlek: Stor -&gt; Liten</string>
+    <string name="sort_badge_ascending">Märke: Rekommenderad -&gt; System</string>
+    <string name="sort_badge_descending">Märke: System -&gt; Rekommenderad</string>
 </resources>
+

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">İptal</string>
     <string name="ok">Tamam</string>
@@ -113,4 +113,14 @@
     <string name="require_auth_setting_desc">Uygulamaları kaldırmak veya yeniden yüklemek için yetkilendirme gerektir.</string>
     <string name="require_auth_setting">Yetkilendirme gerekir</string>
     <string name="enable_usb_debugging">(İsteğe bağlı) USB hata ayıklamasını etkinleştir</string>
+    <string name="sort_by">Şuna göre sırala</string>
+    <string name="sort_name_ascending">Ad: A -&gt; Z</string>
+    <string name="sort_name_descending">Ad: Z -&gt; A</string>
+    <string name="sort_package_ascending">Paket: A -&gt; Z</string>
+    <string name="sort_package_descending">Paket: Z -&gt; A</string>
+    <string name="sort_size_ascending">Boyut: Küçük -&gt; Büyük</string>
+    <string name="sort_size_descending">Boyut: Büyük -&gt; Küçük</string>
+    <string name="sort_badge_ascending">Rozet: Önerilen -&gt; Sistem</string>
+    <string name="sort_badge_descending">Rozet: Sistem -&gt; Önerilen</string>
 </resources>
+

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Скасувати</string>
     <string name="ok">OK</string>
@@ -121,4 +121,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Сортувати за</string>
+    <string name="sort_name_ascending">Назва: A -&gt; Z</string>
+    <string name="sort_name_descending">Назва: Z -&gt; A</string>
+    <string name="sort_package_ascending">Пакет: A -&gt; Z</string>
+    <string name="sort_package_descending">Пакет: Z -&gt; A</string>
+    <string name="sort_size_ascending">Розмір: Малий -&gt; Великий</string>
+    <string name="sort_size_descending">Розмір: Великий -&gt; Малий</string>
+    <string name="sort_badge_ascending">Позначка: Рекомендовано -&gt; Система</string>
+    <string name="sort_badge_descending">Позначка: Система -&gt; Рекомендовано</string>
 </resources>
+

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">Hủy</string>
     <string name="ok">OK</string>
@@ -109,4 +109,14 @@
     <string name="require_auth_setting_desc">Cần xác thực trước khi gỡ hoặc cài đặt lại ứng dụng.</string>
     <string name="require_auth_setting">Yêu cầu xác thực</string>
     <string name="enable_usb_debugging">(Tùy chọn) Bật chế độ gỡ lỗi USB</string>
+    <string name="sort_by">Sắp xếp theo</string>
+    <string name="sort_name_ascending">Tên: A -&gt; Z</string>
+    <string name="sort_name_descending">Tên: Z -&gt; A</string>
+    <string name="sort_package_ascending">Gói: A -&gt; Z</string>
+    <string name="sort_package_descending">Gói: Z -&gt; A</string>
+    <string name="sort_size_ascending">Kích thước: Nhỏ -&gt; Lớn</string>
+    <string name="sort_size_descending">Kích thước: Lớn -&gt; Nhỏ</string>
+    <string name="sort_badge_ascending">Nhãn: Được đề xuất -&gt; Hệ thống</string>
+    <string name="sort_badge_descending">Nhãn: Hệ thống -&gt; Được đề xuất</string>
 </resources>
+

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">取消</string>
     <string name="ok">是的</string>
@@ -109,4 +109,14 @@
     <string name="require_auth_setting_desc">要卸载或重新安装应用，需要身份认证。</string>
     <string name="require_auth_setting">需要身份认证</string>
     <string name="enable_usb_debugging">(可选)启用 USB 调试</string>
+    <string name="sort_by">排序方式</string>
+    <string name="sort_name_ascending">名称：A -&gt; Z</string>
+    <string name="sort_name_descending">名称：Z -&gt; A</string>
+    <string name="sort_package_ascending">软件包：A -&gt; Z</string>
+    <string name="sort_package_descending">软件包：Z -&gt; A</string>
+    <string name="sort_size_ascending">大小：小 -&gt; 大</string>
+    <string name="sort_size_descending">大小：大 -&gt; 小</string>
+    <string name="sort_badge_ascending">徽章：推荐 -&gt; 系统</string>
+    <string name="sort_badge_descending">徽章：系统 -&gt; 推荐</string>
 </resources>
+

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="cancel">取消</string>
     <string name="ok">是的</string>
@@ -109,4 +109,14 @@
     <string name="require_auth_setting_desc">解除安裝或重新安裝應用程式時需要驗證。</string>
     <string name="require_auth_setting">需要驗證</string>
     <string name="enable_usb_debugging">（可選）啟用 USB 除錯</string>
+    <string name="sort_by">排序方式</string>
+    <string name="sort_name_ascending">名稱：A -&gt; Z</string>
+    <string name="sort_name_descending">名稱：Z -&gt; A</string>
+    <string name="sort_package_ascending">套件：A -&gt; Z</string>
+    <string name="sort_package_descending">套件：Z -&gt; A</string>
+    <string name="sort_size_ascending">大小：小 -&gt; 大</string>
+    <string name="sort_size_descending">大小：大 -&gt; 小</string>
+    <string name="sort_badge_ascending">徽章：推薦 -&gt; 系統</string>
+    <string name="sort_badge_descending">徽章：系統 -&gt; 推薦</string>
 </resources>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <resources>
     <string name="app_name" translatable="false">Canta</string>
     <string name="cancel">Cancel</string>
@@ -155,4 +155,14 @@
     <string name="require_auth_setting_desc">Require authentication for uninstalling or reinstalling apps.</string>
     <string name="require_auth_setting">Require authentication</string>
     <string name="enable_usb_debugging">(Optional) Enable USB debugging</string>
+    <string name="sort_by">Sort by</string>
+    <string name="sort_name_ascending">Name: A &#x2192; Z</string>
+    <string name="sort_name_descending">Name: Z &#x2192; A</string>
+    <string name="sort_package_ascending">Package: A &#x2192; Z</string>
+    <string name="sort_package_descending">Package: Z &#x2192; A</string>
+    <string name="sort_size_ascending">Size: Low &#x2192; High</string>
+    <string name="sort_size_descending">Size: High &#x2192; Low</string>
+    <string name="sort_badge_ascending">Badge: Recommended &#x2192; System</string>
+    <string name="sort_badge_descending">Badge: System &#x2192; Recommended</string>
 </resources>
+


### PR DESCRIPTION
Summary

Adds sorting options to the app list and displays the app size.

Changes
Added Sort By options for the app list.
Added sorting functionality based on the available sort criteria.
Added app size information to the app list.
Updated the app list, app tile, top bar, and view model to support sorting.
Added SortByOptions to represent the available sorting options.
Related Issue

Closes #363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sorting options for apps by name, package, size, or removal recommendation, in ascending or descending order.
  * App tiles now display application size with localized formatting.
* **Bug Fixes**
  * App-list scroll position is preserved while browsing and resets appropriately when sorting or filtering changes.
* **Localization**
  * Added translated sorting labels and options across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->